### PR TITLE
Implement showing real fines.

### DIFF
--- a/exe/nypl-cli
+++ b/exe/nypl-cli
@@ -35,7 +35,7 @@ def leave_app
 end
 
 def fetch_fines
-  puts PatienceAndFortitude::ResponseFormatter.fines_response_to_sentence(@client.get_holds)
+  puts PatienceAndFortitude::ResponseFormatter.fines_response_to_sentence(@client.get_fines)
   main_menu
 end
 

--- a/lib/patience_and_fortitude/response_formatter.rb
+++ b/lib/patience_and_fortitude/response_formatter.rb
@@ -20,13 +20,16 @@ module PatienceAndFortitude
     end
 
     def self.fines_response_to_sentence(fines_response)
-      table_data = [
-        {:fine_amount => "$2.03", :title => "Zen and the Art of Motorcycle Maintenance",:due_since => "2017-11-13"},
-        {:fine_amount => "$1.50", :title => "Half Asleep in Frog Pajamas", :due_since => "2017-12-01"},
-        {:fine_amount => "$3.50", :title => "Modern Web Development With Apache Struts", :due_since => "2017-10-05"}
-      ]
-
-      Formatador.display_compact_table(table_data, [:fine_amount, :title, :due_since])
+      fines_array = fines_response[:fines]
+      table_data = []
+      fines_array.each do |fine|
+        table_row = {
+          FINE: fine[:fineAmount],
+          TITLE:  fine[:title]
+        }
+        table_data << table_row
+      end
+      Formatador.display_compact_table(table_data, [:FINE, :TITLE])
     end
   end
 end

--- a/patience_and_fortitude.gemspec
+++ b/patience_and_fortitude.gemspec
@@ -31,11 +31,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'highline', '~> 1.7'
   spec.add_dependency 'whirly', '~> 0.2.6'
-  spec.add_dependency 'nypl-site-scraper', '0.1.0'
+  spec.add_dependency 'nypl-site-scraper', '0.1.1'
   spec.add_dependency 'rainbow', '~> 3.0'
   spec.add_dependency 'paint', '~> 2.0'
   spec.add_dependency 'formatador', '~> 0.2.5'
-  
+
   spec.add_development_dependency "pry", '~> 0.11.3'
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
We were showing fixture / mock data until nypl-site-scraper 0.1.1